### PR TITLE
v0.2.1 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "discord_message_scheduler_bot"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord_message_scheduler_bot"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["beanbeanjuice"]
 

--- a/src/commands/schedule_command.rs
+++ b/src/commands/schedule_command.rs
@@ -214,6 +214,13 @@ pub async fn schedule_command(
     let time = parsed_duration.unwrap();
     let new_message = format!("**{}**: {}", ctx.author().name, message);
 
+    if additional_file.clone().unwrap().size >= 25 * 1000000 {
+        let response: String = format!("Your attachment is too large (25 MB Maximum): {} MB", additional_file.clone().unwrap().size / 1000000);
+
+        ctx.reply(response).await?;
+        return Ok(())
+    }
+
     match add_schedule_to_file(&member.user, &new_message, time, additional_file).await {
         Ok(uuid) => {
             println!("✅  Message saved with UUID {}", uuid);


### PR DESCRIPTION
Made it so if you attach a file that is larger than 25 MB (Discord's Maximum) it will fail to schedule the message.